### PR TITLE
feat: accept external i18n instance via options.i18n

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -24,8 +24,14 @@ const ViurShopComponents = {
 
     app.use(createPinia());
 
+    // Wenn eine i18n-Instanz übergeben wird, diese teilen (keine zweite, konkurrierende
+    // Instanz erzeugen). Sonst eine eigene erstellen (Composition-Mode + globalInjection,
+    // damit $t in Templates und useI18n() denselben Composer nutzen).
+    const sharedI18n = !!options?.i18n
     let messages = {}
-    const i18n = createI18n({
+    const i18n = options?.i18n || createI18n({
+      legacy: false,
+      globalInjection: true,
       locale: defaultLocale,
       fallbackLocale: fallback,
       messages: messages,
@@ -47,9 +53,12 @@ const ViurShopComponents = {
       }
       updateLocaleMessages(loc, messages[loc])
     }
-    app.use(
-      i18n
-    );
+    // Geteilte Instanz wird vom Host (main.js) via app.use() installiert — hier nicht doppelt.
+    if (!sharedI18n) {
+      app.use(
+        i18n
+      );
+    }
   },
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -24,9 +24,9 @@ const ViurShopComponents = {
 
     app.use(createPinia());
 
-    // Wenn eine i18n-Instanz übergeben wird, diese teilen (keine zweite, konkurrierende
-    // Instanz erzeugen). Sonst eine eigene erstellen (Composition-Mode + globalInjection,
-    // damit $t in Templates und useI18n() denselben Composer nutzen).
+    // If an i18n instance is passed in, share it (don't create a second, competing
+    // instance). Otherwise create our own (Composition mode + globalInjection so that
+    // $t in templates and useI18n() use the same composer).
     const sharedI18n = !!options?.i18n
     let messages = {}
     const i18n = options?.i18n || createI18n({
@@ -53,7 +53,7 @@ const ViurShopComponents = {
       }
       updateLocaleMessages(loc, messages[loc])
     }
-    // Geteilte Instanz wird vom Host (main.js) via app.use() installiert — hier nicht doppelt.
+    // A shared instance is installed by the host (main.js) via app.use() — don't install it twice here.
     if (!sharedI18n) {
       app.use(
         i18n


### PR DESCRIPTION
## Problem

When a host application already manages its own `vue-i18n` instance, `ViurShopComponents` still creates a **second, competing** instance in its `install()`. With two instances, `$t` in templates and `useI18n()` in script can resolve to **different composers**, so a locale change applied to one does not propagate to the other (templates stay on the default locale).

This was hit in a real project (******): the user's language showed correctly in the top bar but page content stayed German, because the templates rendered against the ShopComponents instance whose locale was never changed.

## Change

- `install(app, options)` now uses `options.i18n` when provided, sharing the host's instance instead of creating its own.
- The self-created fallback instance now uses `legacy: false` + `globalInjection: true`, so `$t` (templates) and `useI18n()` share one composer.
- When a shared instance is supplied, the host is responsible for `app.use(i18n)` (we don't install it twice).

## Compatibility

Fully backwards compatible: without `options.i18n` the plugin behaves as before (creates and installs its own instance). Components use `useI18n()` (no Options-API `this.$t`), so the Composition-mode switch is safe.